### PR TITLE
transform() now works with coordinates instead of pixels

### DIFF
--- a/Drawing.js
+++ b/Drawing.js
@@ -1,3 +1,5 @@
+'use strict'
+
 class Drawing {
     constructor(points) {
         this.points = points;
@@ -27,3 +29,6 @@ class Drawing {
     }
 }
 
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+    module.exports = Drawing;
+}

--- a/Drawing.js
+++ b/Drawing.js
@@ -1,58 +1,29 @@
 class Drawing {
-    constructor(ctx, w, h, imgData, canvas, points) {
-        this.ctx = ctx;
-        this.h = h;
-        this.w = w;
-        this.imgData = imgData;
-        this.canvas = canvas;
+    constructor(points) {
         this.points = points;
     }
 
-    setPixel(x, y) {
-        this.imgData.data[(x+y*this.w)*4]   = 0;
-        this.imgData.data[(x+y*this.w)*4+1] = 0;
-        this.imgData.data[(x+y*this.w)*4+2] = 0;
-        this.imgData.data[(x+y*this.w)*4+3] = 255;
-    }
-
-    setColoredPixel(x, y, r, g, b, alpha) {
-        this.imgData.data[(x+y*this.w)*4]   = r;
-        this.imgData.data[(x+y*this.w)*4+1] = g;
-        this.imgData.data[(x+y*this.w)*4+2] = b;
-        this.imgData.data[(x+y*this.w)*4+3] = alpha;
-    }
-
-    draw2() {
-        this.imgData = this.ctx.createImageData(this.w, this.h);
-        for(let point of this.points)
-            this.setPixel(Math.round(point.x), Math.round(point.y));
-        this.ctx.putImageData(this.imgData, 0, 0);
-    }
-
-    getAlpha (x, y) { return this.imgData.data[(x+y*this.w)*4+3]; }
-
-    setAlpha (x, y, a) { this.imgData.data[(x+y*this.w)*4+3] = a; }
-
     transform (f) {
-        const dOld = new Drawing(ctx, this.canvas.width, this.canvas.height, this.imgData, this.canvas, imgDataToPoints(this.imgData) );
-        this.imgData = ctx.createImageData(this.canvas.width, this.canvas.height);
-        this.points = [];
-        for (let i=0; i<dOld.points.length; i++) {
-            let newCoord = f(dOld.points[i].x, dOld.points[i].y);
-            let o = {y: newCoord.y , x: newCoord.x}
-            this.points.push(o);
+        const newPoints = [];
+        for (let i=0; i< this.points.length; i++) {
+            let newCoord = f(this.points[i].x, this.points[i].y);
+            newPoints.push({y: newCoord.y , x: newCoord.x});
         }
+        return new Drawing(newPoints)
+    }
+    toCanvasPixels(canvasWidth) {
+        const pixels = [];
+        for (let point of this.points) {
+            const x = Math.round(point.x);
+            const y = Math.round(point.y);
+            const pixelIdx = x + y * canvasWidth;
+            const pixelStart = pixelIdx*4;
+            // pixels[pixelStart]   = 0;
+            // pixels[pixelStart+1] = 0;
+            // pixels[pixelStart+2] = 0;
+            pixels[pixelStart+3] = 255;
+        }
+        return pixels;
     }
 }
 
-function imgDataToPoints(imData) {
-    let points = [];
-    for(let i=3; i<imData.data.length; i+=4) {
-        if (imData.data[i] != 0) {
-            let y = Math.floor(((i-3)/4)/this.w)+1;
-            let o = {y: y, x: ((i-3)/4)%y };
-            points.push(o);
-        }
-    }
-    return points;
-}

--- a/First.html
+++ b/First.html
@@ -4,6 +4,6 @@
 <body>
 <canvas id="canvas" width="900" height="400" style="border: 1px solid black"></canvas>
 <script src="Drawing.js"></script>
-<script src="firstJS.js"></script>
+<script src="app.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ania3drotations",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "mocha": "9.1.1",
+    "mocha-junit-reporter": "2.0.0",
+    "mocha-multi-reporters": "1.5.1"
+  },
+  "scripts": {
+    "test": "mocha \"./src/test/js/**/*Test.js\" --exclude \"./src/test/js/integration/*.js\" --exclude \"./src/test/js/ui-automated/*.js\" --exit"
+  }
+}

--- a/src/test/js/DrawingTest.js
+++ b/src/test/js/DrawingTest.js
@@ -1,0 +1,11 @@
+const Drawing = require('../../../Drawing');
+const assert = require('assert');
+
+describe('Drawing', ()=> {
+    it('transforms pixels according to specified function', () => {
+        const d = new Drawing([]);
+        assert.strictEqual(d.points.length, 0);
+    });
+});
+
+


### PR DESCRIPTION
1. Install NodeJS
2. Write couple simple tests for Drawing
3. Introduce Drawing coordinates
4. When moving Smile - change drawing coordinates instead of
re-calculating pixels
5. When moving drawing - just change coordinates of the drawing
itself (not its pixels)